### PR TITLE
Added scope to fix tests after merge

### DIFF
--- a/Spacebattle.Tests/StartMoveCommandTests.cs
+++ b/Spacebattle.Tests/StartMoveCommandTests.cs
@@ -11,7 +11,7 @@ public class LongOperationTest
     {
         // making 'IoC.Register' start working
         new InitScopeBasedIoCImplementationCommand().Execute();  
-
+IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set", IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
         var moveCommandStartable = new Mock<IMoveCommandStartable>(); 
         // initialize properties for mock object
         moveCommandStartable.SetupGet(mcs => mcs.Target).Returns( new Mock<IUObject>().Object ); 


### PR DESCRIPTION
После слияния обеих частей второй лабораторной стали сбоить тесты. Для исправления был добавлен скоуп в тест первой части второй лабораторной (StartMoveCommand)